### PR TITLE
Mission 인증 페이지 UI 구현

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+  	<string>사진 라이브러리 사용에 필요합니다.</string>
 </dict>
 </plist>

--- a/lib/Presentation/Mission/detail_screen.dart
+++ b/lib/Presentation/Mission/detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'custom_app_bar.dart';
+import 'package:homission/Presentation/Mission/mission_certification_screen.dart';
 
 class MissionDetailScreen extends StatefulWidget {
   const MissionDetailScreen({super.key});
@@ -212,6 +213,17 @@ class _MissionDetailScreenState extends State<MissionDetailScreen> {
                   setState(() {
                     isParticipating = !isParticipating;
                   });
+                                    if (isParticipating) {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => const CertificationScreen()),
+                    );
+                  } else {
+                    setState(() {
+                      isParticipating = !isParticipating;
+                    });
+                  }
                 },
                 child: Text(
                   isParticipating ? '인증하기' : '참여하기',

--- a/lib/Presentation/Mission/mission_certification_screen.dart
+++ b/lib/Presentation/Mission/mission_certification_screen.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'dart:io';
+
+class CertificationScreen extends StatefulWidget {
+  const CertificationScreen({super.key});
+
+  @override
+  _CertificationScreenState createState() => _CertificationScreenState();
+}
+
+class _CertificationScreenState extends State<CertificationScreen> {
+  final ImagePicker _picker = ImagePicker();
+  List<XFile> _imageFileList = [];
+  final TextEditingController _textController = TextEditingController();
+
+  void _pickImage() async {
+    final List<XFile>? selectedImages = await _picker.pickMultiImage();
+    if (selectedImages != null && selectedImages.isNotEmpty) {
+      setState(() {
+        _imageFileList.addAll(selectedImages);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        centerTitle: true,
+        title: const Text(
+          '인증',
+          style: TextStyle(
+            color: Color.fromRGBO(17, 17, 17, 1),
+            fontFamily: 'Pretendard',
+            fontSize: 16,
+            fontWeight: FontWeight.normal,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: GestureDetector(
+        onTap: () {
+          FocusScope.of(context).unfocus();
+        },
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minHeight: constraints.maxHeight,
+                ),
+                child: IntrinsicHeight(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      const SizedBox(height: 32), // 상단 앱바와의 여백
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 4),
+                            decoration: BoxDecoration(
+                              color: const Color.fromRGBO(208, 230, 255, 1),
+                              borderRadius: BorderRadius.circular(100),
+                            ),
+                            child: const Text(
+                              '참여중',
+                              style: TextStyle(
+                                color: Color.fromRGBO(72, 156, 255, 1),
+                                fontFamily: 'Pretendard',
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                          const Text(
+                            '현재 888명 참여',
+                            style: TextStyle(
+                              color: Color.fromRGBO(135, 135, 135, 1),
+                              fontFamily: 'Pretendard',
+                              fontSize: 12,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      const Text(
+                        '온라인 구직신청',
+                        style: TextStyle(
+                          color: Color.fromRGBO(17, 17, 17, 1),
+                          fontFamily: 'Pretendard',
+                          fontSize: 20,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      const Text(
+                        '‘온라인 구직신청’ 을 완료 후 화면을 캡쳐하여 업로드해주세요!',
+                        style: TextStyle(
+                          color: Color.fromRGBO(40, 40, 40, 1),
+                          fontFamily: 'Pretendard',
+                          fontSize: 14,
+                        ),
+                      ),
+                      const SizedBox(height: 32),
+                      SizedBox(
+                        height: 120,
+                        child: ListView.builder(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _imageFileList.length + 1,
+                          itemBuilder: (context, index) {
+                            if (index == _imageFileList.length) {
+                              return GestureDetector(
+                                onTap: _pickImage,
+                                child: Container(
+                                  margin: const EdgeInsets.only(right: 8),
+                                  width: 120,
+                                  height: 120,
+                                  decoration: BoxDecoration(
+                                    borderRadius: BorderRadius.circular(8),
+                                    border: Border.all(
+                                      color: const Color.fromRGBO(
+                                          226, 226, 226, 1),
+                                    ),
+                                  ),
+                                  child: const Center(
+                                    child: Icon(
+                                      Icons.camera_alt,
+                                      color: Color.fromRGBO(226, 226, 226, 1),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            } else {
+                              return Container(
+                                margin: const EdgeInsets.only(right: 8),
+                                width: 120,
+                                height: 120,
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(8),
+                                  image: DecorationImage(
+                                    image: FileImage(
+                                        File(_imageFileList[index].path)),
+                                    fit: BoxFit.cover,
+                                  ),
+                                ),
+                              );
+                            }
+                          },
+                        ),
+                      ),
+                      const SizedBox(height: 32),
+                      Expanded(
+                        child: Container(
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 24, vertical: 24),
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(8),
+                            color: const Color.fromRGBO(245, 245, 245, 1),
+                          ),
+                          child: TextField(
+                            controller: _textController,
+                            maxLines: null, // 입력 줄바꿈 가능하게 설정
+                            expands: true, // 텍스트 필드가 남은 모든 공간을 차지
+                            decoration: const InputDecoration(
+                              hintText: '미션 수행 후기를 남겨주세요!',
+                              hintStyle: TextStyle(
+                                color: Color.fromRGBO(190, 190, 190, 1),
+                                fontFamily: 'Pretendard',
+                                fontSize: 14,
+                              ),
+                              border: InputBorder.none,
+                            ),
+                            style: const TextStyle(
+                              color: Color.fromRGBO(0, 0, 0, 1),
+                              fontFamily: 'Pretendard',
+                              fontSize: 14,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16), // 하단 여백
+                      SizedBox(
+                        height: 58, // 버튼 높이 58로 설정
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor:
+                                const Color.fromRGBO(17, 17, 17, 1),
+                            padding: const EdgeInsets.symmetric(vertical: 16),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          onPressed: () {
+                            // 인증하기 버튼 클릭 시 처리 로직 추가
+                          },
+                          child: const Text(
+                            '인증하기',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontFamily: 'Pretendard',
+                              fontSize: 16,
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 16), // 하단 여백
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+void main() {
+  runApp(const MaterialApp(
+    home: CertificationScreen(),
+  ));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
   flutter_svg: ^1.0.3
+  image_picker: ^0.8.4+4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# 인증 화면 구현

## 목적
미션 상세 조회 화면에서 "인증하기" 버튼을 클릭하면 인증 화면으로 이동하는 기능을 구현합니다. 인증 화면에서는 사용자가 이미지를 첨부하고, 미션 수행 후기를 작성할 수 있습니다.

## 업무 내용

### 1. 인증 화면 UI 구현

#### 상단 영역
- 좌측 상단에 '참여중' 상태 라벨 표시
- 우측 상단에 현재 참여자 수 표시

#### 중앙 영역
- 미션 제목 및 설명 텍스트 표시
- 이미지 첨부 버튼(카메라 아이콘) 배치
- 이미지가 첨부되면 횡스크롤로 이미지를 표시

#### 하단 영역
- 미션 수행 후기를 작성할 수 있는 텍스트 박스 배치
- "인증하기" 버튼 배치

### 2. 이미지 첨부 기능 구현
- `ImagePicker` 패키지를 사용하여 갤러리에서 다중 이미지 선택 기능 구현
- 선택한 이미지는 인증 화면에서 횡스크롤 뷰로 표시

### 3. 인증하기 버튼 기능 구현
- 버튼 클릭 시 이미지를 서버에 업로드하고, 후기를 제출하는 기능 구현

### 4. 네비게이션 기능 구현
- 미션 상세 조회 화면에서 "인증하기" 버튼을 클릭하면 인증 화면으로 이동하도록 구현

## 스크린샷

<img width="585" alt="image" src="https://github.com/eigen98/Homission/assets/68258365/29bbb06f-c61b-46ec-a425-d9655a2d1307">
